### PR TITLE
Initial release docs: README, vignette, and pkgdown website

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,6 +6,7 @@
 ^cran-comments\.md$
 ^CRAN-SUBMISSION$
 ^_pkgdown\.yml$
+^\.github$
 ^docs$
 ^pkgdown$
 ^revdep$

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,40 @@
+name: pkgdown
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev libssl-dev libxml2-dev
+
+      - name: Install R dependencies
+        run: |
+          install.packages(c("pkgdown", "remotes"), repos = "https://cloud.r-project.org")
+          remotes::install_deps(dependencies = TRUE, repos = "https://cloud.r-project.org")
+        shell: Rscript {0}
+
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+        shell: Rscript {0}
+
+      - name: Deploy to gh-pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: docs

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,6 +11,8 @@ Description: Tools to generate synthetic patient-level test datasets in the
     OMOP Common Data Model (CDM). Includes a chat-driven generator backed by
     large language models and an interactive Shiny designer for editing CDM
     test sets
+URL: https://github.com/mi-erasmusmc/patientGenerator
+BugReports: https://github.com/mi-erasmusmc/patientGenerator/issues
 License: Apache License (>= 2)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
@@ -37,4 +39,6 @@ Imports:
 Suggests:
     knitr,
     rmarkdown
+VignetteBuilder: knitr
+Config/Needs/website: pkgdown
 Config/testthat/edition: 3

--- a/README.Rmd
+++ b/README.Rmd
@@ -1,0 +1,113 @@
+---
+output: github_document
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+# patientGenerator
+
+`patientGenerator` helps you build OMOP CDM synthetic test sets in two complementary ways:
+
+- `patientChat`: generate structured patient JSON with an LLM.
+- `patientDesigner`: review and edit those patients in a D3/Shiny interface.
+
+It also includes Hecate-powered concept lookup support for selecting valid OMOP concept codes.
+
+## Install
+
+```r
+# install.packages("pak")
+pak::pak("mi-erasmusmc/patientGenerator")
+```
+
+## Workflow overview
+
+1. Generate a first synthetic cohort with `patientChat`.
+2. Save JSON test sets to disk.
+3. Open `patientDesigner()` to review and refine patients.
+4. Use built-in concept search (backed by `hecateSearch`) while editing tables.
+
+## Generate with patientChat
+
+```r
+library(patientGenerator)
+
+# Requires OPENAI_API_KEY in your environment
+generator <- patientChat$new(model = "gpt-5.2", echo = "none")
+generator$prompt(
+  "Generate 5 synthetic OMOP CDM v5.4 patients with one observation period each."
+)
+
+# Save in the package-managed test set directory
+generator$save(name = "demo-cohort")
+```
+
+### Optional: use your own concept list during generation
+
+```r
+codelist <- readRDS(
+  system.file("concept_sets", "ovarian_cancer_codelist.rds", package = "patientGenerator")
+)
+
+generator <- patientChat$new(
+  model = "gpt-5.2",
+  codelist_data = codelist,
+  echo = "none"
+)
+
+generator$retrieveCodelist(concept_label = "ovarian", domain = "Condition")
+```
+
+## Review and edit in patientDesigner
+
+```r
+# Opens the D3/Shiny editor
+patientDesigner()
+```
+
+Inside the UI you can:
+
+- load existing JSON test sets,
+- add/update/delete rows in OMOP tables,
+- inspect timeline and table previews,
+- save updated test sets.
+
+## Concept code search with Hecate in patientDesigner
+
+`patientDesigner` uses a concept search module that calls `hecateSearch()` under the hood.
+When editing concept ID fields, you can search and insert valid OMOP concept IDs.
+
+Configure Hecate globally with environment variables:
+
+```r
+Sys.setenv(
+  HECATE_BASE_URL = "https://your-hecate-server/api",
+  HECATE_API_KEY = "your-api-key"
+)
+```
+
+Or with package options:
+
+```r
+options(patientgenerator.hecate = list(
+  base_url = "https://your-hecate-server/api",
+  timeout_ms = 15000,
+  api_key = "your-api-key"
+))
+```
+
+## Learn more
+
+- Vignette: `vignette("synthetic-patient-workflow", package = "patientGenerator")`
+- Reference docs are available in the package website built with `pkgdown`.
+
+## Build the website
+
+```r
+pkgdown::build_site()
+```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,102 @@
+# patientGenerator
+
+`patientGenerator` helps you build OMOP CDM synthetic test sets in two complementary ways:
+
+- `patientChat`: generate structured patient JSON with an LLM.
+- `patientDesigner`: review and edit those patients in a D3/Shiny interface.
+
+It also includes Hecate-powered concept lookup support for selecting valid OMOP concept codes.
+
+## Install
+
+```r
+# install.packages("pak")
+pak::pak("mi-erasmusmc/patientGenerator")
+```
+
+## Workflow overview
+
+1. Generate a first synthetic cohort with `patientChat`.
+2. Save JSON test sets to disk.
+3. Open `patientDesigner()` to review and refine patients.
+4. Use built-in concept search (backed by `hecateSearch`) while editing tables.
+
+## Generate with patientChat
+
+```r
+library(patientGenerator)
+
+# Requires OPENAI_API_KEY in your environment
+generator <- patientChat$new(model = "gpt-5.2", echo = "none")
+generator$prompt(
+  "Generate 5 synthetic OMOP CDM v5.4 patients with one observation period each."
+)
+
+# Save in the package-managed test set directory
+generator$save(name = "demo-cohort")
+```
+
+### Optional: use your own concept list during generation
+
+```r
+codelist <- readRDS(
+  system.file("concept_sets", "ovarian_cancer_codelist.rds", package = "patientGenerator")
+)
+
+generator <- patientChat$new(
+  model = "gpt-5.2",
+  codelist_data = codelist,
+  echo = "none"
+)
+
+generator$retrieveCodelist(concept_label = "ovarian", domain = "Condition")
+```
+
+## Review and edit in patientDesigner
+
+```r
+# Opens the D3/Shiny editor
+patientDesigner()
+```
+
+Inside the UI you can:
+
+- load existing JSON test sets,
+- add/update/delete rows in OMOP tables,
+- inspect timeline and table previews,
+- save updated test sets.
+
+## Concept code search with Hecate in patientDesigner
+
+`patientDesigner` uses a concept search module that calls `hecateSearch()` under the hood.
+When editing concept ID fields, you can search and insert valid OMOP concept IDs.
+
+Configure Hecate globally with environment variables:
+
+```r
+Sys.setenv(
+  HECATE_BASE_URL = "https://your-hecate-server/api",
+  HECATE_API_KEY = "your-api-key"
+)
+```
+
+Or with package options:
+
+```r
+options(patientgenerator.hecate = list(
+  base_url = "https://your-hecate-server/api",
+  timeout_ms = 15000,
+  api_key = "your-api-key"
+))
+```
+
+## Learn more
+
+- Vignette: `vignette("synthetic-patient-workflow", package = "patientGenerator")`
+- Reference docs are available in the package website built with `pkgdown`.
+
+## Build the website
+
+```r
+pkgdown::build_site()
+```

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,41 @@
+template:
+  bootstrap: 5
+
+home:
+  title: patientGenerator
+  description: Generate and curate OMOP CDM synthetic patient test sets with LLM and D3 tooling.
+
+navbar:
+  structure:
+    left: [home, reference, articles]
+    right: [github]
+  components:
+    github:
+      icon: fab fa-github
+      href: https://github.com/mi-erasmusmc/patientGenerator
+
+articles:
+  - title: Workflows
+    navbar: Workflows
+    contents:
+      - synthetic-patient-workflow
+
+reference:
+  - title: Generation APIs
+    contents:
+      - patientChat
+      - patientChatNaive
+      - availableModels
+  - title: Design and Curation
+    contents:
+      - patientDesigner
+      - getTestSets
+      - conceptSearchUI
+      - conceptSearchServer
+  - title: Vocabulary Search
+    contents:
+      - hecateClient
+      - hecateSearch
+  - title: Utilities
+    contents:
+      - "%||%"

--- a/vignettes/synthetic-patient-workflow.Rmd
+++ b/vignettes/synthetic-patient-workflow.Rmd
@@ -1,0 +1,131 @@
+---
+title: "Generate and Review Synthetic OMOP Patients"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Generate and Review Synthetic OMOP Patients}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+## Overview
+
+This article shows an end-to-end workflow with `patientGenerator`:
+
+1. generate synthetic patients in OMOP CDM format with `patientChat`,
+2. inspect and curate those patients with `patientDesigner`,
+3. use Hecate concept search from the designer while editing concept IDs.
+
+```{r setup}
+library(patientGenerator)
+```
+
+## 1) Generate a synthetic cohort with patientChat
+
+`patientChat` is an R6 class that prompts an LLM and returns schema-constrained JSON.
+
+```{r chat-example, eval = FALSE}
+# OPENAI_API_KEY must be available in your environment
+generator <- patientChat$new(model = "gpt-5.2", echo = "none")
+
+generator$prompt(
+  paste(
+    "Generate exactly 5 synthetic patients in OMOP CDM v5.4.",
+    "Include one observation period and at least one condition occurrence per patient."
+  )
+)
+
+# Save to default test-set location managed by the package
+generator$save(name = "five-patients-demo")
+```
+
+### Optional: assist generation with a concept list
+
+If you provide a concept list (`concept_id`, `concept_name`, `domain_id`, etc.),
+`patientChat` can use it via the internal retrieval tool during generation.
+
+```{r chat-codelist, eval = FALSE}
+codelist <- readRDS(
+  system.file("concept_sets", "ovarian_cancer_codelist.rds", package = "patientGenerator")
+)
+
+generator <- patientChat$new(
+  model = "gpt-5.2",
+  codelist_data = codelist,
+  echo = "none"
+)
+
+generator$retrieveCodelist(concept_label = "ovarian", domain = "Condition")
+```
+
+## 2) Review and edit generated cohorts in patientDesigner
+
+`patientDesigner()` starts a D3/Shiny application where you can load, review, and edit JSON test sets.
+
+```{r designer-open, eval = FALSE}
+patientDesigner()
+```
+
+Main capabilities in the app:
+
+- browse and load available JSON test sets,
+- edit `person`, `observation_period`, `condition_occurrence`, `drug_exposure`, and `measurement`,
+- inspect timeline and raw table outputs,
+- save updated cohorts back to JSON.
+
+You can also target a specific folder:
+
+```{r designer-path, eval = FALSE}
+patientDesigner(path = "/path/to/my/testsets")
+```
+
+## 3) Search concept codes with Hecate from the designer
+
+The concept search module in `patientDesigner` uses `hecateSearch()` under the hood.
+This helps you find OMOP concept IDs while filling concept fields.
+
+### Configure Hecate with environment variables
+
+```{r hecate-env, eval = FALSE}
+Sys.setenv(
+  HECATE_BASE_URL = "https://your-hecate-server/api",
+  HECATE_API_KEY = "your-api-key",
+  HECATE_TIMEOUT_MS = "15000"
+)
+```
+
+### Or configure with package options
+
+```{r hecate-options, eval = FALSE}
+options(patientgenerator.hecate = list(
+  base_url = "https://your-hecate-server/api",
+  timeout_ms = 15000,
+  api_key = "your-api-key"
+))
+```
+
+### Direct Hecate search example
+
+```{r hecate-search, eval = FALSE}
+res <- hecateSearch(
+  query = "hypertension",
+  domainId = "Condition",
+  standardConcept = "S",
+  limit = 20
+)
+
+head(res)
+```
+
+## Practical recommendations
+
+- Start with small cohorts (1 to 5 patients) to validate your prompts.
+- Keep prompts explicit about OMOP tables and required fields.
+- Use `patientDesigner` for quality control before sharing test sets.
+- Use Hecate filters (`domainId`, `standardConcept`) to reduce ambiguous concept matches.


### PR DESCRIPTION
## Summary
This PR prepares the first public-facing documentation bundle for the initial release.

## What is included
- Adds a complete `README.Rmd` and rendered `README.md`.
- Adds a workflow vignette: `vignettes/synthetic-patient-workflow.Rmd`.
- Adds pkgdown site configuration: `_pkgdown.yml`.
- Adds GitHub Actions workflow to build/deploy docs website: `.github/workflows/pkgdown.yaml`.
- Updates `DESCRIPTION` with project metadata and docs tooling fields:
  - `URL`, `BugReports`
  - `VignetteBuilder: knitr`
  - `Config/Needs/website: pkgdown`
- Updates `.Rbuildignore` to exclude GitHub workflow files from source builds.

## Why
This establishes a clear onboarding path for users and reviewers by documenting the core workflow:
1. Generate synthetic cohorts with `patientChat`.
2. Review/edit cohorts in `patientDesigner` (D3 app).
3. Use Hecate concept search for concept code lookup while curating records.

## Validation
- Branch status verified: `develop` is ahead of `main` by this documentation commit.
- No API behavior changes were introduced in this PR.

## Release impact
Low risk. This is documentation and packaging metadata work intended for the initial release publication workflow.
