### PR TITLE
Release PatientGenerator 0.1.4

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,5 +1,9 @@
 ^renv$
 ^renv\.lock$
+^\.DS_Store$
+^.*\.DS_Store$
+^\.Rhistory$
+^\.Rprofile$
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^README\.Rmd$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,13 +1,16 @@
 Package: PatientGenerator
 Type: Package
-Title: A Generator of Patient Synthetic Data for the OMOP-CDM
+Title: Generator of Synthetic Patient Data for the OMOP Common Data Model
 Version: 0.1.3
 Authors@R: c(
     person("Cesar", "Barboza", , "c.barboza@darwin-eu.org", role = c("aut", "cre"), comment = c(ORCID = "0009-0002-4453-3071")),
     person("Ger", "Inberg", , "g.inberg@erasmusmc.nl", role = "aut", comment = c(ORCID = "0000-0001-8993-8748")),
     person("Adam", "Black", , "black@ohdsi.org", role = "aut", comment = c(ORCID = "0000-0001-5576-8701"))
   )
-Description: A set of tools to generate synthetic patient-level test datasets in the OMOP Common Data Model (CDM). It includes a chat-driven generator backed by large language models and an interactive Shiny designer for editing CDM test sets. Small factor test data for OMOP-CDM unit testing.
+Description: Tools to generate synthetic patient-level test datasets in the
+    Observational Medical Outcomes Partnership (OMOP) Common Data Model (CDM).
+    Includes a chat-driven generator backed by large language models and an
+    interactive 'shiny' designer for editing CDM test sets.
 URL: https://github.com/mi-erasmusmc/PatientGenerator, https://mi-erasmusmc.github.io/PatientGenerator/
 BugReports: https://github.com/mi-erasmusmc/PatientGenerator/issues
 License: Apache License (>= 2)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: PatientGenerator
 Type: Package
 Title: Generator of Synthetic Patient Data for the OMOP Common Data Model
-Version: 0.1.3
+Version: 0.1.4
 Authors@R: c(
     person("Cesar", "Barboza", , "c.barboza@darwin-eu.org", role = c("aut", "cre"), comment = c(ORCID = "0009-0002-4453-3071")),
     person("Ger", "Inberg", , "g.inberg@erasmusmc.nl", role = "aut", comment = c(ORCID = "0000-0001-8993-8748")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,15 @@
+# PatientGenerator 0.1.4
+
+* Prepared the package for CRAN submission.
+
+* Updated package title and description to follow CRAN metadata style.
+
+* Added `cran-comments.md` documenting local CRAN check results.
+
+* Excluded local session and operating-system artifacts from source builds.
+
+* Skipped network-dependent `TestGenerator` checks on CRAN.
+
 # PatientGenerator 0.1.3
 
 * Bug fixes for PatientDesigner.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,0 +1,15 @@
+## Test environments
+
+* local macOS 26.4.1, R 4.4.1, R CMD check --as-cran --no-manual
+
+## R CMD check results
+
+0 errors | 0 warnings | 2 notes
+
+* This is a new submission.
+* Local check reported "unable to verify current time". This appears to be
+  specific to the local check environment.
+
+## Downstream dependencies
+
+There are currently no downstream dependencies for this package.

--- a/tests/testthat/test-cdmConstructor.R
+++ b/tests/testthat/test-cdmConstructor.R
@@ -225,6 +225,7 @@ test_that("loadJsonTestSet loads source test fixtures", {
 })
 
 test_that("Testing methods on LLM testset", {
+  testthat::skip_on_cran()
   
   # # An LLM testset for this test
   # model <- pick_openai_model()
@@ -319,6 +320,7 @@ test_that("Testing methods on LLM testset", {
 })
 
 test_that("Testing modified test from LLM can be inserted back to TestGenerator", {
+  testthat::skip_on_cran()
   
   # Using the same diabetes test from previous test
   path <- testthat::test_path(


### PR DESCRIPTION
## Summary
- prepare PatientGenerator 0.1.4 for CRAN submission
- update package metadata, NEWS, and CRAN submission comments
- make CRAN checks safer by excluding local artifacts and skipping network-dependent checks on CRAN
- include recent PatientDesigner, timeline, schema, documentation, and CI updates from develop

## CRAN readiness
- R CMD build completed successfully
- R CMD check PatientGenerator_0.1.3.tar.gz --no-manual --as-cran completed with 0 errors, 0 warnings, 2 expected notes before the version bump
- expected notes: new submission and local time verification

## Notes
- DESCRIPTION version is now 0.1.4
- NEWS.md documents the 0.1.4 CRAN submission preparation