### PR TITLE
add action: uses table_concept_id if available

### DIFF
--- a/R/cdmTableModules.R
+++ b/R/cdmTableModules.R
@@ -124,17 +124,24 @@ cdmTableServer <- function(
       observeEvent(
         input$add,
         {
-          # browser()
           # Require add button and the person id
           req(input$add)
           req(person_id_selected)
           # Create new event for that person in object
           date_inputs <- columnList[grep("_date$", columnList)]
+          add_inputs <- c(date_inputs, intersect(table_concept_id, columnList))
           input_data <- setNames(
-            lapply(date_inputs, function(col) input[[col]]),
-            date_inputs
+            lapply(add_inputs, function(col) input[[col]]),
+            add_inputs
           )
-          input_data <- input_data[!vapply(input_data, is.null, logical(1))]
+          input_data <- input_data[
+            vapply(input_data, function(value) {
+              if (is.null(value) || length(value) == 0 || all(is.na(value))) {
+                return(FALSE)
+              }
+              any(nzchar(trimws(as.character(value))))
+            }, logical(1))
+          ]
           args <- c(
             list(person_id = person_id_selected() |> as.integer()),
             input_data

--- a/R/cdmTableModules.R
+++ b/R/cdmTableModules.R
@@ -119,6 +119,7 @@ cdmTableServer <- function(
       lapply(concept_status_ids, function(output_id) {
         output[[output_id]] <- shiny::renderUI(NULL)
       })
+      field_update <- reactiveVal(0L)
 
       ### ADD --------------------------------------------------------------------
       observeEvent(
@@ -263,8 +264,8 @@ cdmTableServer <- function(
           list(event_id = as.integer(input[[table_event_id]])),
           no_date_inputs
         )
-        # browser()
         do.call(cdm[[id]]$update, args)
+        field_update(field_update() + 1L)
       })
 
       # # Delete event
@@ -339,6 +340,7 @@ cdmTableServer <- function(
           list(
             add_click = reactive(input$add),
             delete_click = reactive(input$delete),
+            field_update = reactive(field_update()),
             elongation_click = reactive(elongation_click())
           ),
           setNames(list(reactive(input[[table_event_id]])), table_event_id)

--- a/R/patientsDesigner.R
+++ b/R/patientsDesigner.R
@@ -450,6 +450,7 @@ patientDesigner <- function(path = NULL,
       data_version()
       observation_period_module$add_click()
       observation_period_module$delete_click()
+      observation_period_module$field_update()
       observation_period_module$elongation_click()
       formatDateColumns(cdm$observation_period$data())
     })
@@ -469,6 +470,7 @@ patientDesigner <- function(path = NULL,
       data_version()
       drug_exposure_module$add_click()
       drug_exposure_module$delete_click()
+      drug_exposure_module$field_update()
       drug_exposure_module$elongation_click()
       formatDateColumns(cdm$drug_exposure$data())
     })
@@ -486,6 +488,7 @@ patientDesigner <- function(path = NULL,
       data_version()
       condition_occurrence_module$add_click()
       condition_occurrence_module$delete_click()
+      condition_occurrence_module$field_update()
       condition_occurrence_module$elongation_click()
       formatDateColumns(cdm$condition_occurrence$data())
     })
@@ -502,6 +505,7 @@ patientDesigner <- function(path = NULL,
       data_version()
       measurement_module$add_click()
       measurement_module$delete_click()
+      measurement_module$field_update()
       measurement_module$elongation_click()
       formatDateColumns(cdm$measurement$data())
     })
@@ -518,6 +522,7 @@ patientDesigner <- function(path = NULL,
       data_version()
       procedure_occurrence_module$add_click()
       procedure_occurrence_module$delete_click()
+      procedure_occurrence_module$field_update()
       procedure_occurrence_module$elongation_click()
       formatDateColumns(cdm$procedure_occurrence$data())
     })
@@ -534,6 +539,7 @@ patientDesigner <- function(path = NULL,
       data_version()
       observation_module$add_click()
       observation_module$delete_click()
+      observation_module$field_update()
       observation_module$elongation_click()
       cdm$observation$data()
     })
@@ -550,21 +556,27 @@ patientDesigner <- function(path = NULL,
       person_module(),
       observation_period_module$add_click(),
       observation_period_module$delete_click(),
+      observation_period_module$field_update(),
       observation_period_module$elongation_click(),
       drug_exposure_module$add_click(),
       drug_exposure_module$delete_click(),
+      drug_exposure_module$field_update(),
       drug_exposure_module$elongation_click(),
       condition_occurrence_module$add_click(),
       condition_occurrence_module$delete_click(),
+      condition_occurrence_module$field_update(),
       condition_occurrence_module$elongation_click(),
       measurement_module$add_click(),
       measurement_module$delete_click(),
+      measurement_module$field_update(),
       measurement_module$elongation_click(),
       procedure_occurrence_module$add_click(),
       procedure_occurrence_module$delete_click(),
+      procedure_occurrence_module$field_update(),
       procedure_occurrence_module$elongation_click(),
       observation_module$add_click(),
       observation_module$delete_click(),
+      observation_module$field_update(),
       observation_module$elongation_click(),
       ignoreInit = FALSE
     )

--- a/tests/testthat/test-cdmTableModules.R
+++ b/tests/testthat/test-cdmTableModules.R
@@ -80,6 +80,59 @@ test_that("cdmTableServer 'add action' uses entered condition occurrence dates",
   expect_equal(dat$condition_end_date[[1]], as.Date("2021-07-11"))
 })
 
+test_that("cdmTableServer 'add action' uses current condition occurrence concept", {
+  cdm <- new_cdm()
+  cdm$person$add(gender_concept_id = 8532L, year_of_birth = 1970L)
+  cdm$condition_occurrence$add(
+    person_id = 1L,
+    condition_concept_id = 201826L
+  )
+
+  syncing <- shiny::reactiveVal(FALSE)
+
+  shiny::testServer(cdm_table_server,
+    args = list(
+      id = "condition_occurrence",
+      cdm = cdm,
+      person_id_selected = shiny::reactive("1"),
+      syncing = syncing,
+      concept_lookup = function(concept_id) "(Condition)"
+    ), {
+      session$setInputs(condition_occurrence_id = 1L)
+      session$setInputs(condition_concept_id = "201826")
+      session$setInputs(add = 1)
+    }
+  )
+
+  dat <- cdm$condition_occurrence$data()
+  expect_equal(nrow(dat), 2L)
+  expect_equal(dat$condition_concept_id[[2]], 201826L)
+})
+
+test_that("cdmTableServer 'add action' keeps default concept when current concept is empty", {
+  cdm <- new_cdm()
+  cdm$person$add(gender_concept_id = 8532L, year_of_birth = 1970L)
+
+  syncing <- shiny::reactiveVal(FALSE)
+
+  shiny::testServer(cdm_table_server,
+    args = list(
+      id = "condition_occurrence",
+      cdm = cdm,
+      person_id_selected = shiny::reactive("1"),
+      syncing = syncing,
+      concept_lookup = function(concept_id) "(Condition)"
+    ), {
+      session$setInputs(condition_concept_id = "")
+      session$setInputs(add = 1)
+    }
+  )
+
+  dat <- cdm$condition_occurrence$data()
+  expect_equal(nrow(dat), 1L)
+  expect_equal(dat$condition_concept_id[[1]], 44191562L)
+})
+
 test_that("cdmTableServer persists manually entered concept ids", {
   cdm <- new_cdm()
   cdm$person$add(gender_concept_id = 8532L, year_of_birth = 1970L)


### PR DESCRIPTION
see #50 
add operation:
- use given concept_id if available
- extend current check for empty values
- add test